### PR TITLE
Include node_modules in publish.

### DIFF
--- a/aspnetcore-angular-sample.csproj
+++ b/aspnetcore-angular-sample.csproj
@@ -29,7 +29,7 @@
     <Exec Command="node node_modules/webpack/bin/webpack.js --env.prod" />
     <!-- Include the newly-built files in the publish output -->
     <ItemGroup>
-      <DistFiles Include="wwwroot\dist\**; ClientApp\dist\**; chartModule.js" />
+      <DistFiles Include="wwwroot\dist\**; ClientApp\dist\**; chartModule.js; node_modules\**" />
       <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
         <RelativePath>%(DistFiles.Identity)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>


### PR DESCRIPTION
When I visit the chart page after deploying to Azure, I saw this error message;

> An unhandled exception occurred while processing the request.
> 
> Exception: Call to Node module failed with error: Error: Cannot find module 'node-chartist'

There wasn't any node_modules at all. I saw it in CI build console log but not in the artifact. So I included node_modules folder to the publish list of the csproj file. It isn't a good approach to solve this on production but at least it works now.